### PR TITLE
Update httpi and wasabi in compatibility mode

### DIFF
--- a/savon_zuora.gemspec
+++ b/savon_zuora.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency "builder",     ">= 2.1.2"
   s.add_dependency "nori_savon",  "1.1.5"
-  s.add_dependency "httpi",       "~> 1.1.0"
+  s.add_dependency "httpi",       "~> 2.3"
   # s.add_dependency "wasabi",      "~> 2.1"
-  s.add_dependency "wasabi",      "~> 2.5.0"
+  s.add_dependency "wasabi",      "~> 3.4"
   s.add_dependency "akami",       "~> 1.0"
   s.add_dependency "gyoku",       ">= 0.4.0"
   s.add_dependency "nokogiri",    ">= 1.4.0"


### PR DESCRIPTION
@nburwell this is an attempt to fix the compatibility issues when upgrading [Invoca/google-api-ads-ruby](https://github.com/Invoca/google-api-ads-ruby)  to v201509. 

cc: @dangrozasv 
